### PR TITLE
Change the "main" and "types" fields in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yukinojs",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "Kawaii lavalink client written in TypeScript",
   "type": "module",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "type": "git",
     "url": "git+https://github.com/YukinoJs/yukino.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "jest",


### PR DESCRIPTION
This pull request updates the `package.json` file to reflect a new version and adjust the paths for the main and types entries.

Key changes:

* Updated the package version from `1.2.0` to `1.2.2` to indicate a new release. (`[package.jsonL3-R11](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R11)`)
* Changed the `main` and `types` paths to point to `dist/src/index.js` and `dist/src/index.d.ts`, respectively, instead of `dist/index.js` and `dist/index.d.ts`. (`[package.jsonL3-R11](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R11)`)